### PR TITLE
Prevent using the pid as db path

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -297,7 +297,7 @@ exports.instanciateWalletPool = ({ dbPath }) => {
    * @return: resolved path
    */
   NJSPathResolverImpl.resolvePreferencesPath = pathToResolve => {
-    let hash = `${pathToResolve.replace(/\//g, '__')}_${process.pid}`
+    let hash = pathToResolve.replace(/\//g, '__')
     return path.resolve(dbPath, `./preferences_${hash}`)
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/ledger-core",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",
   "repository": {


### PR DESCRIPTION
Tested with 999 concurrency, didn't had any lock issue (hot reloading app, relaunching it, creating tx, sync...)