### PR TITLE
Fix lib linking for older macOS versions

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -43,7 +43,7 @@
           'OTHER_LDFLAGS': [
             '-framework IOKit',
             '-framework CoreFoundation',
-            '-Xlinker -rpath -Xlinker @loader_path'
+            '-Xlinker -rpath -Xlinker @loader_path/'
           ],
         },
       }],


### PR DESCRIPTION
I didn't managed to force the linker to use `@loader_path` but this seems to also do the trick.