### PR TITLE
Use valid syntax for octal integer

### DIFF
--- a/preinstall.py
+++ b/preinstall.py
@@ -39,4 +39,4 @@ if userPlatform == "Windows":
     opener.retrieve(endpointURL + "/crypto.dll", "lib/crypto.dll")
 
 if userPlatform != "Windows":
-    os.chmod(finalFile, 0755)
+    os.chmod(finalFile, 0o755)


### PR DESCRIPTION
0755 is not recognized as an octal integer, causing builds using this to fail with a `SyntaxError: invalid token`. This is why the `ledger-live` PKGBUILD for Arch Linux fails. `0o755` is correct.