### PR TITLE
Fix accessibility level to nan::ObjectWrap.

### DIFF
--- a/src/NJSObjectWrapper.hpp
+++ b/src/NJSObjectWrapper.hpp
@@ -10,7 +10,7 @@ namespace djinni {
 namespace js {
 
 template<typename T>
-class ObjectWrapper: protected Nan::ObjectWrap {
+class ObjectWrapper: public Nan::ObjectWrap {
 public:
     static void Wrap(const std::shared_ptr<T>& realObjectPtr, v8::Local<v8::Object> newHandleExposedToJS) {
 		auto wrapper = new ObjectWrapper(realObjectPtr);


### PR DESCRIPTION
Should be fine as we call wrapper->Nan::ObjectWrap::Wrap(newHandleExposedToJS)
with full name specifier.