### PR TITLE
Bump version to 2.0.0-rc.19.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/ledger-core",
-  "version": "2.0.0-rc.18",
+  "version": "2.0.0-rc.19",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",
   "repository": {

--- a/preinstall.py
+++ b/preinstall.py
@@ -2,7 +2,7 @@ import platform
 import urllib
 import os
 
-libCoreVersion = "2.5.0"
+libCoreVersion = "2.5.0-rc"
 
 baseURL = "https://s3-eu-west-1.amazonaws.com/ledger-lib-ledger-core"
 filePath = ""


### PR DESCRIPTION
This one allows people to test with release-candidates directly on NPM.