### PR TITLE
Improve support for older OSes

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -24,9 +24,6 @@ jobs:
       - name: config gcc
         if: runner.os == 'Linux'
         run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
-      - name: config yarn
-        if: runner.os == 'Windows'
-        run: yarn config set msbuild_path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
       - name: prebuild for electron 8
         run: npx node-pre-gyp configure build package --runtime=electron --target=8.1.0 --build-from-source --dist-url=https://electronjs.org/headers
       - name: prebuild for node 12

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-16.04, macos-latest, windows-2016]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@master
@@ -21,9 +21,9 @@ jobs:
         run: yarn --frozen-lockfile --ignore-scripts
       - name: fetch libcore
         run: yarn preinstall
-      - name: config yarn
-        if: runner.os == 'Windows'
-        run: yarn config set msbuild_path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
+      - name: config gcc
+        if: runner.os == 'Linux'
+        run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
       - name: prebuild for electron 7
         run: npx node-pre-gyp configure build package --runtime=electron --target=7.1.9 --build-from-source --dist-url=https://electronjs.org/headers
       - name: prebuild for electron 8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/ledger-core",
-  "version": "6.1.0",
+  "version": "6.2.0-alpha.0",
   "libcoreVersion": "3.3.0-rc-ba8a38",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/ledger-core",
   "version": "6.2.0-alpha.4",
-  "libcoreVersion": "3.3.0-rc-d293f2",
+  "libcoreVersion": "3.3.0-rc-83e843",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/ledger-core",
-  "version": "6.2.0-alpha.2",
+  "version": "6.2.0-alpha.3",
   "libcoreVersion": "3.3.0-rc-d293f2",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/ledger-core",
-  "version": "6.2.0-alpha.1",
+  "version": "6.2.0-alpha.2",
   "libcoreVersion": "3.3.0-rc-ba8a38",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/ledger-core",
   "version": "6.2.0-alpha.2",
-  "libcoreVersion": "3.3.0-rc-ba8a38",
+  "libcoreVersion": "3.3.0-rc-d293f2",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/ledger-core",
-  "version": "6.2.0-alpha.0",
+  "version": "6.2.0-alpha.1",
   "libcoreVersion": "3.3.0-rc-ba8a38",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/ledger-core",
-  "version": "6.2.0-alpha.3",
+  "version": "6.2.0-alpha.4",
   "libcoreVersion": "3.3.0-rc-d293f2",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/ledger-core",
-  "version": "6.2.0-alpha.4",
+  "version": "6.2.0-alpha.5",
   "libcoreVersion": "3.3.0-rc-83e843",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",

--- a/preinstall.js
+++ b/preinstall.js
@@ -15,7 +15,7 @@ const perPlatform = {
     chmod: 0o755,
   },
   win32: {
-    dir: 'win/vs2015',
+    dir: 'win/vs2017',
     files: ['ledger-core.dll', 'ledger-core.lib', 'crypto.dll'],
   },
 }
@@ -30,7 +30,6 @@ const dir =
   process.platform === 'linux' && Number(process.version.match(/^v(\d+\.\d+)/)[1]) >= 10
     ? `${conf.dir}-arch_ssl_1_1`
     : conf.dir
-
 
 const endpointURL = `https://s3-eu-west-1.amazonaws.com/ledger-lib-ledger-core/${libcoreVersion}/${dir}`
 


### PR DESCRIPTION
Tentative improvement/fix for compatibility with less than up-to-date OSes

- Use GCC 7 on Linux (as recommended in our own [README](https://github.com/LedgerHQ/lib-ledger-core-node-bindings/blob/master/README.md) :trollface:)
- Use VS C++ 2017 (as recommended by [Microsoft](https://github.com/microsoft/nodejs-guidelines/blob/master/windows-environment.md#environment-setup-and-configuration) 🚎)
